### PR TITLE
Add gradle configuration for fetching artifacts from Predicare reposi…

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -34,15 +34,16 @@ android {
 
 dependencies {
     // PREDICARE LIBS
-    implementation("se.predicare:core-data:0+")
-    implementation("se.predicare:journal-lib:0+")
+    implementation("se.predicare:core-data-jvm:0.2.0-SNAPSHOT")
+    implementation("se.predicare:journal-lib-jvm:0.2.1-SNAPSHOT")
+    implementation("se.predicare:journal-client-jvm:0.2.1-SNAPSHOT")
     implementation(project(":shared"))
     implementation("com.google.android.material:material:1.5.0")
     implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.3")
     implementation("androidx.activity:activity-compose:1.5.0-alpha02")
     implementation("androidx.navigation:navigation-compose:2.4.1")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.10")
+    implementation(kotlin("stdlib"))
     implementation("androidx.compose.material:material:$compose_version")
     implementation("androidx.compose.ui:ui:$compose_version")
     androidTestImplementation("junit:junit:4.13.2")

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -3,6 +3,7 @@ val compose_version: String by project
 plugins {
     id("com.android.application")
     kotlin("android")
+    id("net.linguica.maven-settings")
 }
 
 android {
@@ -32,6 +33,9 @@ android {
 }
 
 dependencies {
+    // PREDICARE LIBS
+    implementation("se.predicare:core-data:0+")
+    implementation("se.predicare:journal-lib:0+")
     implementation(project(":shared"))
     implementation("com.google.android.material:material:1.5.0")
     implementation("androidx.appcompat:appcompat:1.4.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
-        classpath("com.android.tools.build:gradle:7.1.2")
+        classpath("com.android.tools.build:gradle:7.1.3")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    // Plugin to read credentials from maven configuration.
+    // The plugin must also be specified in subprojects.
+    id("net.linguica.maven-settings") version "0.5"
+}
+
 buildscript {
     repositories {
         gradlePluginPortal()
@@ -14,6 +20,14 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://pkgs.dev.azure.com/predicare/_packaging/retts-ng/maven/v1")
+            name = "retts-ng"
+            // Credentials are read from `$HOME/.m2/settings.xml`.
+            authentication {
+                create<BasicAuthentication>("basic")
+            }
+        }
     }
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
+    id("net.linguica.maven-settings")
 }
 
 kotlin {


### PR DESCRIPTION
This PR adds configuration to use Predicare libraries.

This PR will cause build failures unless the machine is has a maven-configuration with a token which allows access to the artifacts.

The maven config is located at `~/.m2/settings.xml`, and the file should look like:

```xml
<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
  <servers>

    <server>
      <id>retts-ng</id>
      <username>predicare</username>
      <password>[PERSONAL_ACCESS_TOKEN]</password>
    </server>

  </servers>
</settings>
```

Where the text `[PERSONAL_ACCESS_TOKEN]` should be replaced with a token provided by me.

Therefore, this should not be merged until we've setup your machines.