### PR TITLE
Add figma colors and typography, add ordination screen shell as example.

### DIFF
--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/AppNavigation.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/AppNavigation.kt
@@ -7,8 +7,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
-import com.EENX15_22_17.digital_journal.android.ui.current.CurrentScreen
+import com.EENX15_22_17.digital_journal.android.screens.treatment.ordination.OrdinationScreen
 import com.EENX15_22_17.digital_journal.android.ui.arrivalpage.ArrivalPage
+import com.EENX15_22_17.digital_journal.android.ui.current.CurrentScreen
 import com.EENX15_22_17.digital_journal.android.ui.landingpage.LandingPage
 import com.EENX15_22_17.digital_journal.android.ui.screen.ContactCauseScreen
 import com.EENX15_22_17.digital_journal.android.ui.triage.history.HealthHistoryPage
@@ -190,7 +191,7 @@ private fun NavGraphBuilder.addPatientMeetingGraph(
         ) { backStackEntry ->
             val visitId = backStackEntry.arguments?.getString("visitId")
             requireNotNull(visitId) { "No patient meeting" }
-            // TODO add medicalOrder composable
+            OrdinationScreen(onBackClicked = navController::popBackStack)
         }
         composable(
             route = PatientMeetingScreen.InterimJournal.createRoute()

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/screens/treatment/ordination/OrdinationScreen.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/screens/treatment/ordination/OrdinationScreen.kt
@@ -1,0 +1,22 @@
+package com.EENX15_22_17.digital_journal.android.screens.treatment.ordination
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.EENX15_22_17.digital_journal.android.ui.DetailPageWrapper
+import com.EENX15_22_17.digital_journal.android.ui.theme.Colors
+
+@Preview
+@Composable
+fun OrdinationScreen(
+    onBackClicked: () -> Unit = {},
+    onMenuClicked: () -> Unit = {},
+) {
+    DetailPageWrapper(
+        title = "Åtgärd / Ordination", // TODO: Use `JournalScreen.ACTIONS_AND_ORDINATIONS.title` when libs are available,
+        titleColor = Colors.treatmentPrimary,
+        onBackClicked = onBackClicked,
+        onMenuClicked = onMenuClicked
+    ) {
+
+    }
+}

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/DetailPageWrapper.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/DetailPageWrapper.kt
@@ -1,0 +1,122 @@
+package com.EENX15_22_17.digital_journal.android.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBackIos
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.EENX15_22_17.digital_journal.android.ui.theme.TextStyles
+
+@Composable
+fun DetailPageWrapper(
+    title: String = "Title",
+    titleColor: Color = Color.Blue,
+    bgColor: Color = lerp(titleColor, Color.White, 0.70f),
+    onMenuClicked: () -> Unit = {},
+    onBackClicked: () -> Unit = {},
+    content: @Composable () -> Unit = { }
+) {
+    Column(Modifier.padding(top = 16.dp, start = 8.dp, end = 16.dp)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            MenuButton(modifier = Modifier.size(32.dp), onClick = onMenuClicked)
+            BackButton(text = "TILLBAKA", onClick = onBackClicked)
+        }
+        Column(Modifier.padding(horizontal = 48.dp)) {
+            ScreenTitleText(
+                text = title.uppercase(),
+                textColor = titleColor,
+                lineColor = bgColor
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+fun ScreenTitleText(
+    modifier: Modifier = Modifier,
+    text: String = "SampleTitle",
+    textColor: Color = Color.Blue,
+    lineColor: Color = lerp(textColor, Color.White, 0.70f),
+    underLine: Boolean = true
+) {
+    Column(modifier) {
+        Text(
+            text = text,
+            color = textColor,
+            style = TextStyles.pageTitle
+        )
+        if (underLine) {
+            Underline(color = lineColor, thickness = 8.dp)
+        }
+    }
+}
+
+@Composable
+fun Underline(
+    modifier: Modifier = Modifier,
+    color: Color = Color.Blue,
+    thickness: Dp = 8.dp,
+    cornerRoundingPercentage: Int = 50
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(thickness)
+            .background(color, RoundedCornerShape(cornerRoundingPercentage))
+    )
+}
+
+@Preview
+@Composable
+fun MenuButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
+) {
+    IconButton(onClick = onClick) {
+        Icon(
+            modifier = modifier,
+            imageVector = Icons.Filled.Menu,
+            contentDescription = "Menu"
+        )
+    }
+}
+
+@Preview
+@Composable
+fun BackButton(
+    text: String = "Back",
+    icon: ImageVector = Icons.Filled.ArrowBackIos,
+    onClick: () -> Unit = {}
+) {
+    Row(
+        modifier = Modifier.clickable { onClick() },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onClick) {
+            Icon(icon, "Back")
+        }
+        Text(
+            text = text,
+            style = TextStyles.iosButton
+        )
+    }
+}

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/landingpage/LandingPage.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/landingpage/LandingPage.kt
@@ -2,25 +2,25 @@ package com.EENX15_22_17.digital_journal.android.ui.landingpage
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
+import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MedicalInformation
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.EENX15_22_17.digital_journal.android.R
-import com.EENX15_22_17.digital_journal.android.ui.theme.rettsLineFourNavigationCard
-import com.EENX15_22_17.digital_journal.android.ui.theme.rettsLineOneNavigationCard
-import com.EENX15_22_17.digital_journal.android.ui.theme.rettsLineTwoNavigationCard
-import androidx.compose.material.icons.Icons
-import androidx.compose.ui.Alignment
-import androidx.compose.material.*
-import androidx.compose.material.icons.rounded.MedicalInformation
 import androidx.compose.ui.unit.sp
+import com.EENX15_22_17.digital_journal.android.R
+import com.EENX15_22_17.digital_journal.android.ui.theme.Colors
+import com.EENX15_22_17.digital_journal.android.ui.theme.TextStyles
 import com.EENX15_22_17.digital_journal.android.ui.theme.colorIcon
 
 
@@ -51,14 +51,14 @@ fun LandingPage(
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {
             NavigationCard(
-                label = R.string.arrivalCard,
-                backgroundCol = rettsLineOneNavigationCard,
+                label = stringResource(R.string.arrivalCard),
+                titleColor = Colors.arrivalPrimary,
                 modifier = Modifier.width(370.dp),
                 navigateToForm = navToArrival
             )
             NavigationCard(
-                label = R.string.hazardCard,
-                backgroundCol = rettsLineOneNavigationCard,
+                label = stringResource(R.string.hazardCard),
+                titleColor = Colors.arrivalPrimary,
                 modifier = Modifier.width(370.dp),
                 navigateToForm = navToHazard
             )
@@ -71,22 +71,22 @@ fun LandingPage(
         )
         {
             NavigationCard(
-                label = R.string.contactReason,
-                backgroundCol = rettsLineTwoNavigationCard,
+                label = stringResource(R.string.contactReason),
+                titleColor = Colors.triagePrimary,
                 modifier = Modifier
                     .width(240.dp),
                 navigateToForm = navToContactReason
             )
             NavigationCard(
-                label = R.string.previousCare,
-                backgroundCol = rettsLineTwoNavigationCard,
+                label = stringResource(R.string.previousCare),
+                titleColor = Colors.triagePrimary,
                 modifier = Modifier
                     .width(240.dp),
                 navigateToForm = navToPreviousCare
             )
             NavigationCard(
-                label = R.string.healthHistory,
-                backgroundCol = rettsLineTwoNavigationCard,
+                label = stringResource(R.string.healthHistory),
+                titleColor = Colors.triagePrimary,
                 modifier = Modifier
                     .width(240.dp),
                 navigateToForm = navToHealthHistory
@@ -100,15 +100,15 @@ fun LandingPage(
         )
         {
             NavigationCard(
-                label = R.string.healthNow,
-                backgroundCol = rettsLineTwoNavigationCard,
+                label = stringResource(R.string.healthNow),
+                titleColor = Colors.triagePrimary,
                 modifier = Modifier
                     .width(370.dp),
                 navigateToForm = navToHealthNow
             )
             NavigationCard(
-                label = R.string.suicideAssessment,
-                backgroundCol = rettsLineTwoNavigationCard,
+                label = stringResource(R.string.suicideAssessment),
+                titleColor = Colors.triagePrimary,
                 modifier = Modifier
                     .width(370.dp),
                 navigateToForm = navToSuicideAssessment
@@ -121,15 +121,15 @@ fun LandingPage(
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {
             NavigationCard(
-                label = R.string.nursingNeed,
-                backgroundCol = rettsLineFourNavigationCard,
+                label = stringResource(R.string.nursingNeed),
+                titleColor = Colors.treatmentPrimary,
                 modifier = Modifier
                     .width(370.dp),
                 navigateToForm = navToNursingNeed
             )
             NavigationCard(
-                label = R.string.medicalOrder,
-                backgroundCol = rettsLineFourNavigationCard,
+                label = stringResource(R.string.medicalOrder),
+                titleColor = Colors.treatmentPrimary,
                 modifier = Modifier
                     .width(370.dp),
                 navigateToForm = navToMedicalOrder
@@ -142,8 +142,8 @@ fun LandingPage(
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {
             NavigationCard(
-                label = R.string.interimJournal,
-                backgroundCol = rettsLineFourNavigationCard,
+                label = stringResource(R.string.interimJournal),
+                titleColor = Colors.treatmentPrimary,
                 modifier = Modifier
                     .width(760.dp),
                 navigateToForm = navToInterimJournal
@@ -186,23 +186,27 @@ fun InfoDisplay() {
 
 @Composable
 fun NavigationCard(
-    label: Int,
-    backgroundCol: Color,
-    modifier: Modifier,
-    navigateToForm: () -> Unit
+    modifier: Modifier = Modifier,
+    label: String = "Title",
+    titleColor: Color = Color.Blue,
+    backgroundColor: Color = lerp(titleColor, Color.White, 0.70f),
+    navigateToForm: () -> Unit = {}
 ) {
     Card(
         modifier = modifier
             .height(180.dp)
             .clickable { navigateToForm() },
-        backgroundColor = backgroundCol,
+        backgroundColor = backgroundColor,
+        elevation = 4.dp,
+        shape = RoundedCornerShape(10.dp)
     ) {
-        Text(
-            stringResource(label),
-            fontWeight = FontWeight.SemiBold,
-            textAlign = TextAlign.Center,
-            fontSize = 30.sp
-        )
+        Row(horizontalArrangement = Arrangement.Center, verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = label,
+                style = TextStyles.cardTitle,
+                color = titleColor
+            )
+        }
     }
 }
 

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/theme/Colors.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/theme/Colors.kt
@@ -1,6 +1,7 @@
 package com.EENX15_22_17.digital_journal.android.ui.theme
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 
 /*TODO: Refactor to not use top level colors */
 val danger = Color(0xFFCD9A50)
@@ -26,3 +27,15 @@ val error = Color(0xFFBA1B1B)
 val onBackgound = Color(0xFF191C1D)
 
 val background = Color(0xFFFBFDFD)
+
+fun Color.brighter(fraction: Float) = lerp(this, Color.White, fraction)
+
+object Colors {
+    val arrivalPrimary = Color(0xFFC64072)
+    val arrivalBackground = arrivalPrimary.brighter(0.7f)
+    val triagePrimary = Color(0xFF3D8085)
+    val triageBackground = arrivalPrimary.brighter(0.7f)
+    val treatmentPrimary = Color(0xFF87618A)
+    val treatmentBackground = arrivalPrimary.brighter(0.7f)
+}
+

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/theme/TextStyles.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/theme/TextStyles.kt
@@ -1,0 +1,23 @@
+package com.EENX15_22_17.digital_journal.android.ui.theme
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+object TextStyles {
+    val pageTitle = TextStyle(
+        fontSize = 36.sp,
+        fontWeight = FontWeight.Normal,
+        letterSpacing = 0.15.sp
+    )
+    val cardTitle = TextStyle(
+        fontSize = 24.sp,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = 0.15.sp
+    )
+    val iosButton = TextStyle(
+        fontSize = 18.sp,
+        fontWeight = FontWeight.Medium,
+        letterSpacing = 0.50.sp
+    )
+}


### PR DESCRIPTION
This branch adds colors and typography taken from Figma to make the landing page more like the design.

It also adds a wrapper composable which contains the title and navigation buttons the are present on all detail screens. An empty ordination screen with only this shell has been added so that this can be tested.