### PR TITLE
Example on saving viewmodelInstance

### DIFF
--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/AppNavigation.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/AppNavigation.kt
@@ -10,6 +10,7 @@ import androidx.navigation.navigation
 import com.EENX15_22_17.digital_journal.android.screens.arrival.patientinfo.ArrivalPage
 import com.EENX15_22_17.digital_journal.android.screens.treatment.ordination.OrdinationScreen
 import com.EENX15_22_17.digital_journal.android.screens.arrival.hazardassesment.HazardAssessment
+import com.EENX15_22_17.digital_journal.android.screens.arrival.patientinfo.ArrivalViewModel
 import com.EENX15_22_17.digital_journal.android.ui.current.CurrentScreen
 import com.EENX15_22_17.digital_journal.android.screens.landingpage.LandingPage
 import com.EENX15_22_17.digital_journal.android.screens.treatment.checkups.TempMedicalCheckup
@@ -84,19 +85,22 @@ sealed class PatientMeetingScreen(val route: String) {
 
 
 @Composable
-fun NavigationApp() {
+fun NavigationApp(
+    arrivalViewModel: ArrivalViewModel
+) {
     val navController = rememberNavController()
     NavHost(
         navController = navController,
         startDestination = Screen.Overview.route
     ) {
         addCurrentBoardGraph(navController = navController)
-        addPatientMeetingGraph(navController = navController)
+        addPatientMeetingGraph(navController = navController, arrivalViewModel = arrivalViewModel)
     }
 }
 
 private fun NavGraphBuilder.addPatientMeetingGraph(
     navController: NavController,
+    arrivalViewModel: ArrivalViewModel
 ) {
     navigation(
         route = Screen.PatientMeeting.route,
@@ -136,6 +140,7 @@ private fun NavGraphBuilder.addPatientMeetingGraph(
             val visitId = backStackEntry.arguments?.getString("visitId")
             requireNotNull(visitId) { "No patient id provided" }
             ArrivalPage(
+                arrivalViewModel,
                 visitId = visitId,
                 navBack = { navController.popBackStack() }
             )

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/MainActivity.kt
@@ -6,15 +6,19 @@ import androidx.activity.compose.setContent
 import androidx.compose.material.Text
 import androidx.compose.material.Button
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModelProvider
+import com.EENX15_22_17.digital_journal.android.screens.arrival.patientinfo.ArrivalViewModel
 import com.EENX15_22_17.digital_journal.android.ui.theme.DigitalJournalTheme
 
 
 class MainActivity : ComponentActivity() {
+    private lateinit var arrivalViewModel: ArrivalViewModel
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        arrivalViewModel = ViewModelProvider(this)[ArrivalViewModel::class.java]
         setContent {
             DigitalJournalTheme {
-                NavigationApp()
+                NavigationApp(arrivalViewModel = arrivalViewModel)
             }
         }
     }

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/screens/arrival/patientinfo/ArrivalScreen.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/screens/arrival/patientinfo/ArrivalScreen.kt
@@ -9,11 +9,13 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
 import com.EENX15_22_17.digital_journal.android.ui.theme.borderColor
 
 @Composable
 fun ArrivalPage(
-    arrivalViewModel: ArrivalViewModel = ArrivalViewModel(),
+    arrivalViewModel: ArrivalViewModel,
     visitId: String,
     navBack: () -> Unit
 ) {
@@ -150,7 +152,7 @@ fun ArrivalPage(
             ) {
                 ArrivalType(
                     choices = arrivalMethods.keys.toTypedArray(),
-                    onChange = { arrivalViewModel.arrivalStates.arrivalMethod = it},
+                    onChange = { arrivalViewModel.arrivalStates.arrivalMethod = it },
                     currentSelected = arrivalViewModel.arrivalStates.arrivalMethod,
                     labels = arrivalMethods
                 )
@@ -170,7 +172,7 @@ fun ArrivalPage(
             ) {
                 Laws(
                     choices = laws.keys.toTypedArray(),
-                    onChange = { arrivalViewModel.arrivalStates.law = it},
+                    onChange = { arrivalViewModel.arrivalStates.law = it },
                     currentSelected = arrivalViewModel.arrivalStates.law,
                     labels = laws
                 )


### PR DESCRIPTION
# Example on how to make a viewmodel survive during the instance.

* Pass the viewmodel parameter through the ArrivalScreen ->
  AppNavigation -> MainActivity. In MainActivity we can set a owner of
  the Viewmodel and provide it with *ViewModelProvider*.

* Dont know if this is a good solution or not, but it works good on the ArrivalScreen.

* Now the ViewModel doesnt creates everytime we enter the Screen.