### PR TITLE
Refactor LandingPageScreen.kt to use library definitions of screens.

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,4 +1,5 @@
 val compose_version: String by project
+val kotlinx_datetime_version: String by project
 
 plugins {
     id("com.android.application")
@@ -34,9 +35,9 @@ android {
 
 dependencies {
     // PREDICARE LIBS
-    implementation("se.predicare:core-data-jvm:0.2.0-SNAPSHOT")
-    implementation("se.predicare:journal-lib-jvm:0.2.1-SNAPSHOT")
-    implementation("se.predicare:journal-client-jvm:0.2.1-SNAPSHOT")
+    implementation("se.predicare:core-data-jvm:0.3.0-SNAPSHOT")
+    implementation("se.predicare:journal-lib-jvm:0.3.2-SNAPSHOT")
+    implementation("se.predicare:journal-client-jvm:0.3.2-SNAPSHOT")
     implementation(project(":shared"))
     implementation("com.google.android.material:material:1.5.0")
     implementation("androidx.appcompat:appcompat:1.4.1")
@@ -44,6 +45,7 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.5.0-alpha02")
     implementation("androidx.navigation:navigation-compose:2.4.1")
     implementation(kotlin("stdlib"))
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinx_datetime_version")
     implementation("androidx.compose.material:material:$compose_version")
     implementation("androidx.compose.ui:ui:$compose_version")
     androidTestImplementation("junit:junit:4.13.2")

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/AppNavigation.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/AppNavigation.kt
@@ -19,6 +19,7 @@ import com.EENX15_22_17.digital_journal.android.ui.screen.ContactCauseScreen
 import com.EENX15_22_17.digital_journal.android.screens.triage.suicideassessment.SuicideAssessmentScreen
 import com.EENX15_22_17.digital_journal.android.screens.triage.somatichealth.SomaticHealthPage
 import com.EENX15_22_17.digital_journal.android.screens.triage.previousCare.TempPreviusCare
+import se.predicare.journal.screens.JournalScreen
 
 sealed class Screen(val route: String) {
     object Current : Screen(route = "current")
@@ -118,16 +119,20 @@ private fun NavGraphBuilder.addPatientMeetingGraph(
 
             LandingPage(
                 visitId = visitId,
-                navToArrival = { navTo(PatientMeetingScreen.Arrival) },
-                navToHazard = { navTo(PatientMeetingScreen.HazardAssessment) },
-                navToContactReason = { navTo(PatientMeetingScreen.ContactReason) },
-                navToPreviousCare = { navTo(PatientMeetingScreen.PreviousCare) },
-                navToHealthHistory = { navTo(PatientMeetingScreen.HealthHistory) },
-                navToHealthNow = { navTo(PatientMeetingScreen.HealthNow) },
-                navToSuicideAssessment = { navTo(PatientMeetingScreen.SuicideAssessment) },
-                navToNursingNeed = { navTo(PatientMeetingScreen.NursingNeed) },
-                navToMedicalOrder = { navTo(PatientMeetingScreen.MedicalOrder) },
-                navToInterimJournal = { navTo(PatientMeetingScreen.InterimJournal) },
+                onNavigate = { screen ->
+                    val target: PatientMeetingScreen = when(screen) {
+                        JournalScreen.PATIENT_INFORMATION -> PatientMeetingScreen.Arrival
+                        JournalScreen.ARRIVAL_HAZARD_ASSESSMENT -> PatientMeetingScreen.HazardAssessment
+                        JournalScreen.CONTACT_REASON -> PatientMeetingScreen.ContactReason
+                        JournalScreen.SUICIDE_ASSESSMENT -> PatientMeetingScreen.SuicideAssessment
+                        JournalScreen.PREVIOUS_CARE -> PatientMeetingScreen.PreviousCare
+                        JournalScreen.SOMATIC_HEALTH -> PatientMeetingScreen.HealthHistory
+                        JournalScreen.TRIAGE_ASSESSMENT -> PatientMeetingScreen.HealthNow
+                        JournalScreen.EVENTS -> PatientMeetingScreen.MedicalOrder
+                        JournalScreen.INTERIM_JOURNAL -> PatientMeetingScreen.InterimJournal
+                    }
+                    navTo(target)
+                },
                 showOverview = { id ->
                     navController.navigate(Screen.PatientOverview.createRoute(visitId = id))
                 }

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/screens/landingpage/LandingPageScreen.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/screens/landingpage/LandingPageScreen.kt
@@ -1,7 +1,9 @@
 package com.EENX15_22_17.digital_journal.android.screens.landingpage
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
@@ -14,150 +16,79 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.EENX15_22_17.digital_journal.android.R
+import com.EENX15_22_17.digital_journal.android.ui.ifMobile
 import com.EENX15_22_17.digital_journal.android.ui.theme.Colors
 import com.EENX15_22_17.digital_journal.android.ui.theme.TextStyles
 import com.EENX15_22_17.digital_journal.android.ui.theme.colorIcon
+import se.predicare.journal.data.Labels.labels
+import se.predicare.journal.screens.JournalScreen
 
-
-@Composable
-fun LandingPage(
-    visitId: String,
-    showOverview: (patientId: String) -> Unit = {},
-    navToArrival: () -> Unit = {},
-    navToHazard: () -> Unit = {},
-    navToContactReason: () -> Unit = {},
-    navToPreviousCare: () -> Unit = {},
-    navToHealthHistory: () -> Unit = {},
-    navToHealthNow: () -> Unit = {},
-    navToSuicideAssessment: () -> Unit = {},
-    navToNursingNeed: () -> Unit = {},
-    navToMedicalOrder: () -> Unit = {},
-    navToInterimJournal: () -> Unit = {}
-) {
-    Column(
-        modifier = Modifier,
-        verticalArrangement = Arrangement.Center
+val navigationSections by lazy {
+    arrayOf(
+        arrayOf(
+            JournalScreen.PATIENT_INFORMATION,
+            JournalScreen.ARRIVAL_HAZARD_ASSESSMENT,
+        ),
+        arrayOf(
+            JournalScreen.CONTACT_REASON,
+            JournalScreen.SUICIDE_ASSESSMENT
+        ),
+        arrayOf(
+            JournalScreen.PREVIOUS_CARE,
+            JournalScreen.SOMATIC_HEALTH,
+            JournalScreen.TRIAGE_ASSESSMENT,
+        ),
+        arrayOf(
+            JournalScreen.EVENTS
+        ),
+        arrayOf(
+            JournalScreen.INTERIM_JOURNAL
+        )
     )
-    {
-        InfoDisplay()
-        Row(
-            modifier = Modifier
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly
-        ) {
-            NavigationCard(
-                label = stringResource(R.string.arrivalCard),
-                titleColor = Colors.arrivalPrimary,
-                modifier = Modifier.width(370.dp),
-                navigateToForm = navToArrival
-            )
-            NavigationCard(
-                label = stringResource(R.string.hazardCard),
-                titleColor = Colors.arrivalPrimary,
-                modifier = Modifier.width(370.dp),
-                navigateToForm = navToHazard
-            )
+}
+
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+@Preview
+fun LandingPage(
+    visitId: String = "1",
+    showOverview: (patientId: String) -> Unit = {},
+    onNavigate: (destination: JournalScreen) -> Unit = {}
+) {
+
+    LazyColumn( modifier = Modifier
+        .padding(62.dp ifMobile 8.dp)
+        .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(24.dp ifMobile 8.dp),
+    ) {
+        stickyHeader {
+            InfoDisplay()
         }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 10.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly
-        )
-        {
-            NavigationCard(
-                label = stringResource(R.string.contactReason),
-                titleColor = Colors.triagePrimary,
-                modifier = Modifier
-                    .width(240.dp),
-                navigateToForm = navToContactReason
-            )
-            NavigationCard(
-                label = stringResource(R.string.previousCare),
-                titleColor = Colors.triagePrimary,
-                modifier = Modifier
-                    .width(240.dp),
-                navigateToForm = navToPreviousCare
-            )
-            NavigationCard(
-                label = stringResource(R.string.somaticHealthTitle),
-                titleColor = Colors.triagePrimary,
-                modifier = Modifier
-                    .width(240.dp),
-                navigateToForm = navToHealthHistory
-            )
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 10.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly
-        )
-        {
-            NavigationCard(
-                label = stringResource(R.string.healthNow),
-                titleColor = Colors.triagePrimary,
-                modifier = Modifier
-                    .width(370.dp),
-                navigateToForm = navToHealthNow
-            )
-            NavigationCard(
-                label = stringResource(R.string.suicideAssessment),
-                titleColor = Colors.triagePrimary,
-                modifier = Modifier
-                    .width(370.dp),
-                navigateToForm = navToSuicideAssessment
-            )
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 10.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly
-        ) {
-            NavigationCard(
-                label = stringResource(R.string.nursingNeed),
-                titleColor = Colors.treatmentPrimary,
-                modifier = Modifier
-                    .width(370.dp),
-                navigateToForm = navToNursingNeed
-            )
-            NavigationCard(
-                label = stringResource(R.string.medicalOrder),
-                titleColor = Colors.treatmentPrimary,
-                modifier = Modifier
-                    .width(370.dp),
-                navigateToForm = navToMedicalOrder
-            )
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 10.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly
-        ) {
-            NavigationCard(
-                label = stringResource(R.string.interimJournal),
-                titleColor = Colors.treatmentPrimary,
-                modifier = Modifier
-                    .width(760.dp),
-                navigateToForm = navToInterimJournal
-            )
-        }
-        Row(
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.Bottom
-        ) {
-            OverViewButton(showOverview = { showOverview(visitId) })
+        items(navigationSections.size) { index ->
+            val screens = navigationSections[index]
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(24.dp ifMobile 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                screens.forEach { screen ->
+                    NavigationCard(
+                        modifier = Modifier
+                            .height(140.dp ifMobile 100.dp)
+                            .weight(1.0f / screens.size.toFloat()),
+                        label = JournalScreen.labels[screen]!!,
+                        titleColor = Colors.journalSectionColors[screen.section]!!,
+                        navigateToForm = { onNavigate(screen) }
+                    )
+                }
+            }
         }
     }
 }
-
 
 /**
  * TODO: When we have avaialable patient data, this card is supposed to display patient information
@@ -172,13 +103,13 @@ fun InfoDisplay() {
         Card(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 10.dp, start = 20.dp, end = 20.dp, top = 10.dp)
                 .height(150.dp),
             elevation = 10.dp
-        )
-        {
-            Text("Namn: Erik Bengtsson", textAlign = TextAlign.Start, fontSize = 20.sp)
-            Text("ID: 1997001122-XXXX", textAlign = TextAlign.End, fontSize = 20.sp)
+        ) {
+            Row(Modifier.padding(8.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("Namn: Erik Bengtsson", textAlign = TextAlign.Start, fontSize = 20.sp)
+                Text("ID: 1997001122-XXXX", textAlign = TextAlign.End, fontSize = 20.sp)
+            }
         }
     }
 }
@@ -194,8 +125,8 @@ fun NavigationCard(
 ) {
     Card(
         modifier = modifier
-            .height(180.dp)
-            .clickable { navigateToForm() },
+            .clickable { navigateToForm() }
+            .padding(2.dp), // Same as shadow elevation since its otherwise cut-of
         backgroundColor = backgroundColor,
         elevation = 4.dp,
         shape = RoundedCornerShape(10.dp)
@@ -204,7 +135,8 @@ fun NavigationCard(
             Text(
                 text = label,
                 style = TextStyles.cardTitle,
-                color = titleColor
+                color = titleColor,
+                textAlign = TextAlign.Center
             )
         }
     }

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/screens/triage/somatichealth/SomaticHealthScreen.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/screens/triage/somatichealth/SomaticHealthScreen.kt
@@ -17,9 +17,11 @@ import com.EENX15_22_17.digital_journal.android.dataModel.YesNo
 import com.EENX15_22_17.digital_journal.android.dataModel.nursesNeeds
 import com.EENX15_22_17.digital_journal.android.dataModel.yesNoLabels
 import com.EENX15_22_17.digital_journal.android.ui.DetailPageWrapper
-import com.EENX15_22_17.digital_journal.android.ui.components.*
+import com.EENX15_22_17.digital_journal.android.ui.components.EnumCheckboxesLazyGrid
+import com.EENX15_22_17.digital_journal.android.ui.components.EnumRadioButtonsHorizontal
+import com.EENX15_22_17.digital_journal.android.ui.components.TitledSection
+import com.EENX15_22_17.digital_journal.android.ui.components.TitledTextField
 import com.EENX15_22_17.digital_journal.android.ui.theme.Colors
-import modifyIf
 
 @Composable
 fun SomaticHealthPage(

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/Utils.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/Utils.kt
@@ -1,4 +1,20 @@
+package com.EENX15_22_17.digital_journal.android.ui
+
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Returns `true` if the screen size is indicative of a mobile device rather than a tablet.
+ */
+@Composable
+fun isMobileScreen(): Boolean {
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    return screenWidth > 10.cm && screenHeight > 10.cm
+}
 
 /**
  * Applies the supplied [modifier] to the chain only if [condition] is `true`.
@@ -9,3 +25,27 @@ fun Modifier.modifyIf(condition: Boolean, modifier: Modifier): Modifier =
     } else {
         this
     }
+
+/**
+ * Converts this [Number] in centimeters to the corresponding length in display-pixels ([Dp])
+ */
+val Number.cm: Dp
+    get() = Dp(this.toFloat() * 62.992126f)
+
+/**
+ * Converts a measurement in [Dp]s into a float representing the same measurement in centimeters.
+ */
+val Dp.cm: Float
+    get() = (this.value / 62.992126f)
+
+/**
+ * infix function to specify an alternate size [mobileDp] if running on a mobile device.
+ */
+@Composable
+infix fun Dp.ifMobile(mobileDp: Dp): Dp {
+    return if (isMobileScreen()) {
+        this
+    } else {
+        mobileDp
+    }
+}

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/components/Checkbuttons.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/components/Checkbuttons.kt
@@ -24,7 +24,7 @@ import com.EENX15_22_17.digital_journal.android.ui.theme.TextStyles
 import com.EENX15_22_17.digital_journal.android.ui.theme.checkboxBackgroundShape
 import com.EENX15_22_17.digital_journal.android.ui.theme.checkboxBoxBackgroundSize
 import com.EENX15_22_17.digital_journal.android.ui.theme.colorCheckBoxBeta
-import modifyIf
+import com.EENX15_22_17.digital_journal.android.ui.modifyIf
 
 
 @Composable

--- a/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/theme/Colors.kt
+++ b/androidApp/src/main/java/com/EENX15_22_17/digital_journal/android/ui/theme/Colors.kt
@@ -2,6 +2,7 @@ package com.EENX15_22_17.digital_journal.android.ui.theme
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
+import se.predicare.journal.screens.JournalSection
 
 /*TODO: Refactor to not use top level colors */
 val danger = Color(0xFFCD9A50)
@@ -35,8 +36,17 @@ object Colors {
     val arrivalBackground = arrivalPrimary.brighter(0.7f)
     val triagePrimary = Color(0xFF3D8085)
     val triageBackground = arrivalPrimary.brighter(0.7f)
+    val eventsPrimary = Color(0xFF78907A)
+    val eventsBackground = arrivalPrimary.brighter(0.7f)
     val treatmentPrimary = Color(0xFF87618A)
     val treatmentBackground = arrivalPrimary.brighter(0.7f)
+
+    val journalSectionColors = mapOf(
+        JournalSection.ARRIVAL to arrivalPrimary,
+        JournalSection.TRIAGE to triagePrimary,
+        JournalSection.EVENTS to eventsPrimary,
+        JournalSection.INTERIM_JOURNAL to treatmentPrimary
+    )
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 
 #Kotlin
 kotlin.code.style=official
+kotlinx_datetime_version=0.3.1
 
 #Android
 android.useAndroidX=true


### PR DESCRIPTION
* Also change layout method to not be as fixed to the screen size. This is to be able to better test the app on mobile devices (even thought the rest of the UI is not compatible, it is now possible to navigate).
* Changes sizing and padding directives to the parent container instead of having the `NavigationCard`s specify their own size.
* Other screens have not been renamed yet, as there are other branches working on those.